### PR TITLE
Fix infinite polling loop causing battery drain

### DIFF
--- a/EFFICIENCY_REPORT.md
+++ b/EFFICIENCY_REPORT.md
@@ -1,0 +1,129 @@
+# Aircon Daikin App - Code Efficiency Analysis Report
+
+## Executive Summary
+
+This report analyzes the Android Kotlin aircon application codebase to identify areas where code efficiency can be improved. The analysis focuses on performance bottlenecks, resource usage optimization, and Android best practices.
+
+## Identified Efficiency Issues
+
+### 1. **CRITICAL: Infinite Polling Loop in MainViewModel**
+
+**Location**: `app/src/main/java/com/example/airconapp/presentation/MainViewModel.kt` (lines 34-41)
+
+**Issue**: The `startPeriodicRefresh()` method uses an infinite `while(true)` loop that continuously polls the API every 5 seconds without proper lifecycle management.
+
+```kotlin
+private fun startPeriodicRefresh() {
+    viewModelScope.launch {
+        while (true) {
+            delay(5000) // Refresh every 5 seconds
+            fetchAirconStatus()
+        }
+    }
+}
+```
+
+**Impact**: 
+- High battery drain due to continuous background processing
+- Unnecessary network requests when app is not visible
+- Potential memory leaks if coroutine is not properly cancelled
+- Poor user experience due to battery consumption
+
+**Recommended Fix**: Replace with a more efficient approach using proper coroutine lifecycle management and consider using Android's WorkManager for background tasks or implement proper pause/resume logic.
+
+### 2. **MEDIUM: Multiple ViewModel Instances in MainActivity**
+
+**Location**: `app/src/main/java/com/example/airconapp/MainActivity.kt` (lines 41, 61, 75, 78, 88, 89)
+
+**Issue**: Multiple `viewModel()` calls create separate instances of the same ViewModel, leading to redundant state management and API calls.
+
+```kotlin
+val mainViewModel: MainViewModel = viewModel() // Line 41
+// ... later in the same composable
+val mainViewModel: MainViewModel = viewModel() // Line 78, 89
+```
+
+**Impact**:
+- Redundant API calls and state management
+- Increased memory usage
+- Potential inconsistent state between screens
+
+**Recommended Fix**: Use a shared ViewModel instance across navigation destinations or implement proper ViewModel scoping.
+
+### 3. **LOW: String Parsing Inefficiencies in AirconApi**
+
+**Location**: `app/src/main/java/com/example/airconapp/data/AirconApi.kt` (lines 94-107, 110-135)
+
+**Issue**: String parsing operations create multiple intermediate objects and use inefficient string operations.
+
+```kotlin
+private fun parseControlInfoString(input: String): ControlInfo {
+    val parts = input.split(",").associate { part ->
+        val (key, value) = part.split("=")
+        key to value
+    }
+    // Multiple map lookups with default values
+}
+```
+
+**Impact**:
+- Unnecessary object creation during parsing
+- Multiple string operations that could be optimized
+- Potential performance impact with frequent API calls
+
+**Recommended Fix**: Use more efficient parsing with StringBuilder or regex patterns, cache parsed results where appropriate.
+
+### 4. **LOW: Multiple mutableStateOf Declarations in AddEditScheduleScreen**
+
+**Location**: `app/src/main/java/com/example/airconapp/ui/screens/AddEditScheduleScreen.kt` (lines 41-49)
+
+**Issue**: Multiple separate `mutableStateOf` declarations instead of using a single data class state.
+
+```kotlin
+var startTime by remember { mutableStateOf("") }
+var endTime by remember { mutableStateOf("") }
+var selectedMode by remember { mutableStateOf("2") }
+var selectedTemperature by remember { mutableStateOf("23") }
+var selectedFanRate by remember { mutableStateOf("A") }
+var selectedZones by remember { mutableStateOf(listOf<Zone>()) }
+var isStartTimeError by remember { mutableStateOf(false) }
+var isZoneSelectionError by remember { mutableStateOf(false) }
+```
+
+**Impact**:
+- Multiple recompositions when state changes
+- Harder to manage related state
+- Potential for inconsistent state updates
+
+**Recommended Fix**: Use a single data class to hold all form state and update it atomically.
+
+### 5. **LOW: Redundant URL Encoding Operations**
+
+**Location**: `app/src/main/java/com/example/airconapp/data/AirconApi.kt` (lines 78-83)
+
+**Issue**: Multiple URL encoding operations and string replacements that could be optimized.
+
+```kotlin
+var encodedZoneOnOffString = URLEncoder.encode(zoneOnOffString, "UTF-8")
+var encodedZoneNameString = URLEncoder.encode(zoneNameString, "UTF-8")
+
+encodedZoneOnOffString = encodedZoneOnOffString.replace("+", "%20")
+encodedZoneNameString = encodedZoneNameString.replace("+", "%20")
+```
+
+**Impact**:
+- Unnecessary string operations
+- Multiple object creations for encoding
+- Could be simplified with proper URL encoding
+
+**Recommended Fix**: Use a more efficient URL encoding approach or create a utility function to handle this pattern.
+
+## Priority Recommendations
+
+1. **Immediate**: Fix the infinite polling loop in MainViewModel (CRITICAL)
+2. **Short-term**: Optimize ViewModel instance management in MainActivity (MEDIUM)
+3. **Long-term**: Refactor string parsing and state management optimizations (LOW)
+
+## Conclusion
+
+The most critical issue is the infinite polling loop which significantly impacts battery life and app performance. Fixing this issue should be the immediate priority, followed by optimizing ViewModel usage patterns. The other issues, while less critical, would improve overall code maintainability and performance when addressed.


### PR DESCRIPTION
# Fix infinite polling loop causing battery drain

## Summary

This PR addresses a critical battery drain issue caused by an infinite polling loop in `MainViewModel`. The original implementation used `while(true)` without proper lifecycle management, causing continuous background API calls even when the app was not visible.

**Key Changes:**
- Added proper coroutine lifecycle management with `Job` tracking
- Implemented `isActive` checks to prevent unnecessary work when coroutine is cancelled
- Added `onCleared()` override to properly cancel the refresh job when ViewModel is destroyed
- Created comprehensive efficiency analysis report documenting this and other performance issues

**Impact:** This fix should significantly reduce battery consumption and eliminate unnecessary background network requests.

## Review & Testing Checklist for Human

- [ ] **Verify polling still works correctly** - Confirm the app continues to refresh aircon status every 5 seconds when active
- [ ] **Test ViewModel lifecycle management** - Navigate between screens and verify polling stops/starts appropriately
- [ ] **Check compilation** - Ensure the new imports and code changes compile without errors
- [ ] **Test battery usage** - Monitor battery consumption before/after the fix to confirm improvement
- [ ] **Verify user experience** - Ensure no regression in data freshness or app responsiveness

**Recommended Test Plan:**
1. Launch the app and verify the main screen updates every 5 seconds
2. Navigate away from the main screen and back - confirm polling resumes
3. Put the app in background/foreground and verify appropriate behavior
4. Check Android's battery usage statistics to confirm reduced consumption

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    MainActivity["MainActivity.kt"]:::context
    MainViewModel["MainViewModel.kt<br/>startPeriodicRefresh()"]:::major-edit
    AirconApi["AirconApi.kt"]:::context
    
    MainActivity --> MainViewModel
    MainViewModel --> AirconApi
    
    subgraph "Polling Mechanism"
        OldLoop["while(true) + delay()"]:::major-edit
        NewLoop["while(isActive) + Job mgmt"]:::major-edit
        OnCleared["onCleared() override"]:::major-edit
    end
    
    MainViewModel --> OldLoop
    MainViewModel --> NewLoop
    MainViewModel --> OnCleared
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- The efficiency report documents 5 total issues found in the codebase, with this infinite polling loop being the most critical
- This fix follows Android best practices for coroutine lifecycle management in ViewModels
- The original polling logic is preserved but now properly respects the coroutine lifecycle

---

**Session Info:**
- Requested by: Eduardo Rodrigues (@eduardoarantes)
- Devin Session: https://app.devin.ai/sessions/d1b040f05d8046df9a6eba3116adb28e