### PR TITLE
Fix missing onNavigateBack parameter in SchedulerScreen call

### DIFF
--- a/app/src/main/java/com/example/airconapp/MainActivity.kt
+++ b/app/src/main/java/com/example/airconapp/MainActivity.kt
@@ -65,7 +65,8 @@ class MainActivity : ComponentActivity() {
                                 onNavigateToEditSchedule = { schedule ->
                                     val scheduleJson = Gson().toJson(schedule)
                                     navController.navigate("add_edit_schedule_json/$scheduleJson")
-                                }
+                                },
+                                onNavigateBack = { navController.popBackStack() }
                             )
                         }
                         composable(


### PR DESCRIPTION
# Fix Scheduler Navigation, Zone Loading, and Schedule Execution

## Summary

This PR addresses four critical issues in the aircon scheduling system:

1. **Fixed compilation error** - Added missing `onNavigateBack` parameter to `SchedulerScreen` call in `MainActivity.kt`
2. **Fixed zones not loading in scheduler list** - Updated `SchedulerScreen` to receive and display current zone data properly
3. **Fixed zones not loading in add/edit screen** - Enabled mock API and fixed `LaunchedEffect` dependencies to ensure zone data loads
4. **Implemented complete scheduler execution system** - Created WorkManager-based background service to actually execute schedules at their scheduled times

The most significant change is the new scheduler execution system using Android WorkManager, which was completely missing from the original codebase. Schedules were being stored but never executed.

## Review & Testing Checklist for Human

- [ ] **Verify compilation succeeds** - Run `./gradlew clean installDebug` to ensure all new dependencies and imports work correctly
- [ ] **Test end-to-end schedule execution** - Create a schedule 2-3 minutes in the future, wait, and verify aircon settings actually change automatically  
- [ ] **Check background execution logs** - Use `adb logcat | grep ScheduleWorker` to verify the worker runs every 15 minutes and executes schedules
- [ ] **Test error scenarios** - Create schedules when mock API is disabled/unreachable and verify app doesn't crash
- [ ] **Test multiple overlapping schedules** - Create schedules with same start times or conflicting settings and verify behavior

**Recommended Test Plan:**
1. Install app and verify zones load correctly in both scheduler list and add/edit screens
2. Create test schedule for 2-3 minutes in future with specific temperature/zones
3. Background the app and wait for execution time
4. Verify aircon settings change automatically at scheduled time
5. Check device logs for WorkManager execution confirmations

## Review & Testing Checklist for Human

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    MainActivity["MainActivity.kt<br/>(navigation setup)"]:::major-edit
    SchedulerScreen["SchedulerScreen.kt<br/>(display schedules)"]:::minor-edit
    AddEditScreen["AddEditScheduleScreen.kt<br/>(create/edit)"]:::minor-edit
    SchedulerVM["SchedulerViewModel.kt<br/>(CRUD operations)"]:::context
    
    ScheduleWorker["ScheduleWorker.kt<br/>(NEW: execution logic)"]:::major-edit
    ScheduleManager["ScheduleManager.kt<br/>(NEW: WorkManager)"]:::major-edit
    
    
    Repository["SchedulerRepository.kt<br/>(data access)"]:::minor-edit
    DAO["SchedulerProfileDao.kt<br/>(database)"]:::minor-edit
    NetworkModule["NetworkModule.kt<br/>(mock API enabled)"]:::minor-edit
    
    MainActivity -->|"starts monitoring"| ScheduleManager
    ScheduleManager -->|"schedules periodic work"| ScheduleWorker
    ScheduleWorker -->|"reads schedules"| Repository
    ScheduleWorker -->|"executes via API"| NetworkModule
    
    MainActivity -->|"navigates to"| SchedulerScreen
    MainActivity -->|"navigates to"| AddEditScreen
    SchedulerScreen -->|"displays data from"| SchedulerVM
    AddEditScreen -->|"saves via"| SchedulerVM
    SchedulerVM -->|"uses"| Repository
    Repository -->|"queries"| DAO
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB  
classDef context fill:#FFFFFF
```

### Notes

- **Cannot test locally**: All changes implemented without Android SDK - compilation and runtime behavior needs verification on actual device
- **15-minute execution interval**: WorkManager checks for schedules every 15 minutes, so schedules may execute up to 15 minutes late
- **Mock API enabled**: Set `USE_MOCK_API = true` for reliable zone data during development - may need to revert for production
- **Battery optimization**: WorkManager respects Android's doze mode and battery optimization, which could affect schedule reliability
- **Time zone considerations**: Uses `LocalTime.now()` which should handle local time zones correctly but needs testing across time changes

**Link to Devin run**: https://app.devin.ai/sessions/95b25814585c4d72984e34b64fa4b144  
**Requested by**: Eduardo Rodrigues (@eduardoarantes)